### PR TITLE
Add parsing for single line fields (`data: omg\n\n\r`).

### DIFF
--- a/hypotesis/consumer.rb
+++ b/hypotesis/consumer.rb
@@ -1,0 +1,26 @@
+require "net/http"
+
+q = Queue.new
+
+trap :INT do
+  q << nil
+end
+
+Thread.new do
+  uri = URI("http://localhost:9292")
+
+  Net::HTTP.start(uri.host, uri.port, read_timeout: 600) do |http|
+    http.request_get "/", "Accept" => "text/event-stream" do |response|
+      response.read_body do |chunk|
+        q.push chunk
+      end
+    end
+    q.push nil
+  end
+end
+
+while(chunk = q.pop)
+  puts chunk
+end
+
+puts "bye"

--- a/hypotesis/emitter.ru
+++ b/hypotesis/emitter.ru
@@ -1,0 +1,49 @@
+require "webrick"
+
+class SSEEvent
+  def initialize(text, type: "message", id: Time.now.to_f)
+    @id   = id
+    @text = text
+    @type = type
+  end
+
+  def event
+    %(event: #{@type}
+id: #{@id}
+data: {
+data: "id": "#{@id}",
+data: "type": "#{@type}",
+data: "text": "#{@text}"
+data: }
+
+)
+  end
+end
+
+server = WEBrick::HTTPServer.new Port: 9292
+
+clients = []
+
+server.mount_proc "/" do |req, res|
+  r,w = IO.pipe
+  clients << w
+
+  res.content_type = 'text/event-stream'
+  res.body = r
+  res.chunked = true
+end
+
+server.mount_proc "/broadcast" do |req, res|
+  clients.each do |client|
+    Thread.new do
+      client << SSEEvent.new("streaming!").event
+    end
+  end
+end
+
+trap :INT do
+  clients.each(&:close)
+  server.shutdown
+end
+
+server.start

--- a/lib/servent.rb
+++ b/lib/servent.rb
@@ -1,4 +1,5 @@
 require "servent/version"
+require "servent/event_source"
 
 module Servent
   # Your code goes here...

--- a/lib/servent/event.rb
+++ b/lib/servent/event.rb
@@ -1,0 +1,56 @@
+module Servent
+  class Event
+    attr_reader :type, :data
+
+    def initialize
+      @data = String.new
+    end
+
+    def parse(stream)
+      StringIO.open(stream) do |io|
+        io.each_line { |line| parse_line line }
+      end
+    end
+
+    private
+
+    def parse_line(line)
+      # empty line?, nothing -> ignore
+      return if line.chomp.rstrip.empty?
+
+      # starts with :, comment -> ignore
+
+      # contains :, field -> split : field => data (remove first space)
+      if line.include?("\u{}") # include? ":"
+        parse_field line
+      end
+
+      # else, field: field = data, data = ''
+    end
+
+    def parse_field(line)
+      field = Field.new(* line.split(":"))
+      @type = field.type
+      @data << "\n" unless @data.empty?
+      @data << field.data
+    end
+  end
+
+  class Field
+    attr_reader :type
+
+    def initialize(type, raw_data)
+      @type = type
+      @raw_data = raw_data.chomp
+    end
+
+    def data
+      @data ||= if @raw_data[0] == "\u{0020}"
+                  # remove first char if it is a space.
+                  @raw_data[1..(@raw_data.length - 1)]
+                else
+                  @raw_data
+                end
+    end
+  end
+end

--- a/lib/servent/event_source.rb
+++ b/lib/servent/event_source.rb
@@ -1,3 +1,5 @@
+require "servent/event"
+
 module Servent
   class EventSource
   end

--- a/lib/servent/event_source.rb
+++ b/lib/servent/event_source.rb
@@ -1,0 +1,4 @@
+module Servent
+  class EventSource
+  end
+end

--- a/spec/servent/event_spec.rb
+++ b/spec/servent/event_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Servent::Event do
+  subject(:event) { described_class.new }
+
+  describe "#parse" do
+    context "data:" do
+      context 'happy path stream: a simple `data: omg\n\r\n`.' do
+        it 'recognizes the simple `data: omg\n\n` pattern as a complete event' do
+          event.parse "data:omg\n"
+          event.parse "\r\n"
+
+          expect(event.type).to eq "data"
+          expect(event.data).to eq "omg"
+        end
+
+        it "remove the first space from `data`" do
+          event.parse "data: omg\n"
+          event.parse "\r\n"
+
+          expect(event.type).to eq "data"
+          expect(event.data).to eq "omg"
+        end
+
+        it 'recognizes when return comes later: `data: omg\n\n\r`' do
+          event.parse "data: omg\n"
+          event.parse "\n\r"
+
+          expect(event.type).to eq "data"
+          expect(event.data).to eq "omg"
+        end
+
+        it 'recognizes when first line is delimited by \r `data: omg\r\n\r`' do
+          event.parse "data: omg\n"
+          event.parse "\n\r"
+
+          expect(event.type).to eq "data"
+          expect(event.data).to eq "omg"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What is that for ❓ 

Recognizes streams formed by a single line with a valid field (name COLON value).